### PR TITLE
🐛 Fix: 채팅 전송을 방 단위 STOMP 채널로 전환하고 WS 인증/confirm 저장 버그 수정

### DIFF
--- a/src/main/java/com/eyedia/eyedia/config/SecurityConfig.java
+++ b/src/main/java/com/eyedia/eyedia/config/SecurityConfig.java
@@ -4,15 +4,21 @@ import com.eyedia.eyedia.config.jwt.JwtAuthenticationFilter;
 import com.eyedia.eyedia.config.jwt.JwtProvider;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.web.servlet.config.annotation.CorsRegistry;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+// CORS for Spring Security
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
 
 @Configuration
-public class SecurityConfig implements WebMvcConfigurer {
+public class SecurityConfig {
 
     private final JwtProvider jwtProvider;
 
@@ -20,14 +26,41 @@ public class SecurityConfig implements WebMvcConfigurer {
         this.jwtProvider = jwtProvider;
     }
 
+    // Spring Security가 인식하는 CORS 설정
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration c = new CorsConfiguration();
+        // 개발 편의상 넓게 허용(운영에서는 도메인 제한 권장)
+        c.setAllowedOriginPatterns(List.of(
+                "http://localhost:5173",   // Vite dev
+                "http://localhost:3000",
+                "http://localhost:8000",
+                "http://localhost:8080",
+                "https://eyedia.netlify.app"
+        ));
+        c.setAllowedMethods(List.of("GET","POST","PUT","DELETE","OPTIONS","PATCH"));
+        c.setAllowedHeaders(List.of("Authorization","Content-Type","X-Requested-With","Accept"));
+        c.setAllowCredentials(true);
+        c.setMaxAge(3600L);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", c);
+        return source;
+    }
+
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
+                // 이 CORS는 위의 corsConfigurationSource()를 사용
                 .cors(Customizer.withDefaults())
                 .csrf(csrf -> csrf.disable())
                 .formLogin(form -> form.disable())
                 .httpBasic(basic -> basic.disable())
                 .authorizeHttpRequests(auth -> auth
+                        // 프리플라이트 허용
+                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+
+                        // 공개 엔드포인트
                         .requestMatchers(
                                 "/api/v1/auth/signup",
                                 "/api/v1/auth/login",
@@ -36,35 +69,23 @@ public class SecurityConfig implements WebMvcConfigurer {
                                 "/v3/api-docs/**",
                                 "/api-docs/**",
                                 "/api/v1/ai/**",
-                                "/api/v1/paintings/**",
                                 "/chat/send-ai-message",
                                 "/ws-stomp", "/ws-stomp/**",
-                                "/",
-                                "/health-check",
-                                "/paintings-push"
+                                "/", "/health-check"
                         ).permitAll()
+
+                        // mock-detect는 인증 필요(Principal 써서 개인 큐로 보내기 때문)
+                        .requestMatchers(HttpMethod.POST, "/api/v1/events/mock-detect").authenticated()
+
+                        // 필요시 paintings는 인증 필요로 두는 걸 권장(지금은 전부 허용돼 있었음)
+                        .requestMatchers("/api/v1/paintings/**").authenticated()
+
+                        // 그 외는 인증
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(new JwtAuthenticationFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
-    }
-
-    @Override
-    public void addCorsMappings(CorsRegistry registry) {
-        registry.addMapping("/**")
-                .allowedOriginPatterns(
-                        "http://localhost:8080",
-                        "http://54.180.228.18:8080",
-                        "http://localhost:3000",
-                        "http://localhost:8000",
-                        "https://eyedia.netlify.app"
-                )
-                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH")
-                .allowedHeaders("*")
-                .exposedHeaders("Set-Cookie")
-                .allowCredentials(true)
-                .maxAge(3600);
     }
 
 }

--- a/src/main/java/com/eyedia/eyedia/config/WebSocketConfig.java
+++ b/src/main/java/com/eyedia/eyedia/config/WebSocketConfig.java
@@ -47,7 +47,8 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
                         "http://localhost:3000",
                         "http://localhost:5173",
                         "https://eyedia.site",
-                        "https://eyedia.netlify.app"
+                        "https://eyedia.netlify.app",
+                        "http://3.34.240.201:8000"
                 )
                 .addInterceptors(authHandshakeInterceptor);
     }

--- a/src/main/java/com/eyedia/eyedia/config/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/eyedia/eyedia/config/jwt/JwtAuthenticationFilter.java
@@ -44,8 +44,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
         String path = request.getRequestURI();
-        // /ws-stomp 경로는 JWT 필터에서 제외
-        return !path.startsWith("/ws-stomp");
+        // 오직 WebSocket 핸드셰이크(/ws-stomp)만 JWT 필터에서 제외
+        return path.startsWith("/ws-stomp")
+                || path.startsWith("/swagger-ui")
+                || path.startsWith("/v3/api-docs")
+                || path.startsWith("/h2-console")
+                || path.startsWith("/api/v1/auth"); // 로그인/회원가입 등은 제외(프로젝트 정책에 맞게)
     }
+
 }
 

--- a/src/main/java/com/eyedia/eyedia/controller/ChatController.java
+++ b/src/main/java/com/eyedia/eyedia/controller/ChatController.java
@@ -5,7 +5,6 @@ import com.eyedia.eyedia.domain.Painting;
 import com.eyedia.eyedia.domain.enums.SenderType;
 import com.eyedia.eyedia.dto.AiToBackendDTO;
 import com.eyedia.eyedia.dto.MessageDTO;
-import com.eyedia.eyedia.dto.PaintingMetadataRequest;
 import com.eyedia.eyedia.repository.MessageRepository;
 import com.eyedia.eyedia.repository.PaintingRepository;
 import lombok.RequiredArgsConstructor;
@@ -14,8 +13,6 @@ import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.RestTemplate;
 
@@ -27,29 +24,20 @@ public class ChatController {
 
     private final SimpMessagingTemplate messagingTemplate;
     private final RestTemplate restTemplate;
-    private static final String MODEL_API_URL = "http://localhost:8000/api/llm/answer"; // FastAPI 실제 API 주소
+    private static final String MODEL_API_URL = "http://3.34.240.201:8000";
     private final PaintingRepository paintingRepository;
     private final MessageRepository messageRepository;
-/**
-    //@MessageMapping("/echo/{roomId}")
-    //@SendTo("/room/{roomId}")
-    public void echo(@Payload String message) {
-        System.out.println("Echo received: " + message);
-        // 구독 중인 모든 /room에 메시지 전송
-        messagingTemplate.convertAndSend("/room", "echo: " + message);
-    }
-*/
 
-
-    @PostMapping("/paintings-push")
-    public PaintingMetadataRequest pushPaintingDetected(@RequestBody PaintingMetadataRequest request,
-    @Header("simpSessionAttributes") Map<String, Object> sessionAttributes) {
-        Long userId = (Long) sessionAttributes.get("userId");
-
-        messagingTemplate.convertAndSend("/room/user-" + userId, request);
-
-        return request;
-    }
+//    @PostMapping("/paintings-push")
+//    public PaintingMetadataRequest pushPaintingDetected(@RequestBody PaintingMetadataRequest request,
+//    @Header("simpSessionAttributes") Map<String, Object> sessionAttributes) {
+//        Long userId = (Long) sessionAttributes.get("userId");
+//
+//        messagingTemplate.convertAndSend("/room/user-" + userId, request);
+//        //messagingTemplate.convertAndSendToUserprincipal.getName(), "/queue/events", payload);
+//
+//        return request;
+//    }
 
     @MessageMapping("/chat.sendMessage")
     public void sendMessage(@Payload MessageDTO.ChatMessageDTO message,
@@ -88,7 +76,7 @@ public class ChatController {
             );
 
             ResponseEntity<MessageDTO.ModelResponseDTO> response = restTemplate.postForEntity(
-                    MODEL_API_URL, payload, MessageDTO.ModelResponseDTO.class
+                    MODEL_API_URL+"/generate-description", payload, MessageDTO.ModelResponseDTO.class
             );
 
             MessageDTO.ModelResponseDTO responseBody = response.getBody();
@@ -119,31 +107,4 @@ public class ChatController {
 
         messagingTemplate.convertAndSend("/room/user-" + userId, aiMessageDto);
     }
-//
-//    @PostMapping("/chat/send-ai-message")
-//    public ResponseEntity<String> sendAiMessage(@RequestBody ObjectDescriptionRequest request) {
-//        /*Long paintingId = request.getPaintingId();*/
-//        Long paintingId = request.geObjectId();
-//        String description = request.getDescription();
-//
-//        Painting painting = paintingRepository.findById(paintingId).orElse(null);
-//        if (painting == null) return ResponseEntity.badRequest().body("Invalid paintingId");
-//
-//        // 메시지 저장
-//        Message aiMessage = Message.builder()
-//                .sender(SenderType.ASSISTANT)
-//                .content(description)
-//                .painting(painting)
-//                .build();
-//        messageRepository.save(aiMessage);
-//
-//        // painting 객체와 연결된 user 정보 사용
-//        Long userId = painting.getUser().getUsersId();
-//        if (userId == null) return ResponseEntity.badRequest().body("User not found for painting");
-//
-//        // 메시지 전송
-//        messagingTemplate.convertAndSend("/room/user-" + userId, request);
-//
-//        return ResponseEntity.ok("Message sent");
-//    }
 }

--- a/src/main/java/com/eyedia/eyedia/controller/DetectionEventController.java
+++ b/src/main/java/com/eyedia/eyedia/controller/DetectionEventController.java
@@ -1,0 +1,39 @@
+package com.eyedia.eyedia.controller;
+
+import com.eyedia.eyedia.dto.MessageDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.security.Principal;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/events")
+public class DetectionEventController {
+
+    private final SimpMessagingTemplate messagingTemplate;
+    /**
+     * 25.08.17 <인식된 사진 프론트 전송>
+     * request : 방 데이터
+     * return : 이미지 id와 url
+     * */
+    @PostMapping("/mock-detect")
+    public ResponseEntity<Void> mockDetect(Principal principal) {
+        String userKey = principal.getName(); // <-- WebSocket CONNECT에서 setUser(...) 한 값
+        String img = "https://upload.wikimedia.org/wikipedia/commons/b/b7/Edgar_Degas_The_Dance_Class.jpg";
+        messagingTemplate.convertAndSendToUser(
+                userKey,
+                "/queue/events",
+                MessageDTO.ChatImageResponseDTO.builder()
+                        .url(img)
+                        .artId(20001L)
+                        .build()
+        );
+        return ResponseEntity.ok().build();
+    }
+
+}

--- a/src/main/java/com/eyedia/eyedia/controller/PaintingController.java
+++ b/src/main/java/com/eyedia/eyedia/controller/PaintingController.java
@@ -24,6 +24,12 @@ public class PaintingController {
     private final PaintingService paintingService;
     private final S3Manager s3Manager;
 
+
+
+    /**
+     * Error: 모델에 문제가 생겨 사용 불가
+     *
+     * */
     @PostMapping("/upload")
     @Operation(summary = "이미지 업로드", description = "모델 서버가 전송한 그림 이미지를 S3에 업로드하고 이미지 URL을 반환합니다.")
     public ApiResponse<String> uploadImage(
@@ -44,11 +50,11 @@ public class PaintingController {
         return ApiResponse.of(SuccessStatus._OK,null);
     }
 
-    @Operation(summary = "그림 확인", description = "사용자가 그림을 확인하고 채팅을 시작여부를 선택합니다.")
-    @PostMapping("/{paintingId}/confirm")
-    public ResponseEntity<PaintingConfirmResponse> confirmPainting(@PathVariable Long paintingId) {
+    @Operation(summary = "채팅방 생성", description = "사용자가 그림을 확인하고 채팅을 시작여부를 선택합니다.")
+    @PostMapping("/{artId}/confirm")
+    public ResponseEntity<PaintingConfirmResponse> confirmPainting(@PathVariable Long artId) {
         // confirm 후 채팅 시작
-        return ResponseEntity.ok(paintingService.confirmPainting(paintingId));
+        return ResponseEntity.ok(paintingService.confirmPainting(artId));
     }
 
     @Operation(summary = "그림 설명 조회", description = "DB에서 그림에 대한 전체적인 설명을 조회합니다.")

--- a/src/main/java/com/eyedia/eyedia/domain/Painting.java
+++ b/src/main/java/com/eyedia/eyedia/domain/Painting.java
@@ -56,4 +56,7 @@ public class Painting extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "users_id")
     private User user;
+
+    @Column(name = "art")
+    private Long artId;
 }

--- a/src/main/java/com/eyedia/eyedia/dto/AiToBackendDTO.java
+++ b/src/main/java/com/eyedia/eyedia/dto/AiToBackendDTO.java
@@ -8,45 +8,6 @@ import lombok.extern.jackson.Jacksonized;
 public class AiToBackendDTO {
 
     @Getter
-    @Builder
-    @AllArgsConstructor
-    @Schema(description = "AI가 백엔드에 전달하는 그림 후보 요청 DTO")
-    public static class MatchingCandidateRequest {
-        @Schema(description = "그림 후보 ID", example = "12")
-        private Long candidateId;
-
-        public Long getPaintingId() {
-            return candidateId;
-        }
-    }
-
-    @Getter
-    @Builder
-    @AllArgsConstructor
-    public static class MatchingCandidateResponse {
-        private Long id;
-        private String title;
-        private String artist;
-        private String imageUrl;
-    }
-
-    @Getter
-    @AllArgsConstructor
-    @NoArgsConstructor
-    public static class PaintingDescriptionRequest {
-        @Schema(description = "그림 ID", example = "1")
-        private Long paintingId;
-    }
-
-    @Getter
-    @AllArgsConstructor
-    @NoArgsConstructor
-    public static class RecaptureResponse {
-        @Schema(description = "재촬영 요청 여부", example = "true")
-        private boolean isSuccess;
-    }
-
-    @Getter
     @Setter
     @NoArgsConstructor
     @AllArgsConstructor

--- a/src/main/java/com/eyedia/eyedia/dto/MessageDTO.java
+++ b/src/main/java/com/eyedia/eyedia/dto/MessageDTO.java
@@ -5,6 +5,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
 
 public class MessageDTO {
+    @Builder
+    @Getter
+    @AllArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class ChatImageResponseDTO {
+        private String url;
+        private Long artId;
+    }
 
     @Builder
     @Getter

--- a/src/main/java/com/eyedia/eyedia/dto/UserFacingDTO.java
+++ b/src/main/java/com/eyedia/eyedia/dto/UserFacingDTO.java
@@ -12,6 +12,7 @@ public class UserFacingDTO {
         private Long paintingId;
         private boolean confirmed;
         private String message;
+        private Long artId;
     }
 
     @Getter

--- a/src/main/java/com/eyedia/eyedia/service/PaintingService.java
+++ b/src/main/java/com/eyedia/eyedia/service/PaintingService.java
@@ -25,7 +25,7 @@ public class PaintingService {
     private final UserRepository userRepository;
     private final ExhibitionRepository exhibitionRepository;
 
-    public PaintingConfirmResponse confirmPainting(Long paintingId) {
+    public PaintingConfirmResponse confirmPainting(Long artId) {
         Long userId = SecurityUtil.getCurrentUserId();
 
         User user = userRepository.findById(userId)
@@ -34,7 +34,7 @@ public class PaintingService {
         // 채팅방 생성 및 사용자 연결
         Painting paintingRoom = Painting.builder()
                 .user(user)
-                .paintingId(paintingId)
+                .artId(artId)
                 .build();
 
         Painting response = paintingRepository.save(paintingRoom);
@@ -43,6 +43,7 @@ public class PaintingService {
                 .chatRoomId(response.getPaintingId())
                 .paintingId(response.getPaintingId())
                 .confirmed(true)
+                .artId(response.getArtId())
                 .message("채팅방을 시작합니다.")
                 .build();
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,3 +10,8 @@ spring:
       - jwt
       - s3
 #      - oauth
+logging:
+  level:
+    org:
+      springframework:
+        security=DEBUG:


### PR DESCRIPTION
# 💡 PR Summary - <!--{ 작업 내용 }--> 채팅 전송을 방 단위 STOMP 채널로 전환하고 WS 인증/confirm 저장 버그 수정
<!-- 어떤 작업에 대한 PR 인지 위 주석에 적어주세요 -->

### 📝 Description

---
<!-- 어떤 작업을 했는지 간단하게 적어주세요 -->

채팅 브로드캐스트 채널을 /room/{roomId} 기반으로 전환

개인 큐 /user/queue/events 는 모델 감지 알림용으로 유지

WebSocket 인증/핸드셰이크 정리 (shouldNotFilter, SecurityConfig)

confirmPainting() 저장 예외 수정 (detached entity)

### 🌲 Working Branch

---
<!-- 예시) feature/user -->
작업 브랜치
- fix/56-connect-model
### 📖 Related Issues

---
<!-- 예시) #1 -->
이슈 번호
- #56 

### 📚 Etc

---
<!-- 작업 중 특이사항이 생기면 적어주세요 -->
특이사항