### PR TITLE
✨ Feat: 비밀번호 변경 유효성 검사 및 커스텀 에러 응답 처리 개선

### DIFF
--- a/src/main/java/com/eyedia/eyedia/controller/UserController.java
+++ b/src/main/java/com/eyedia/eyedia/controller/UserController.java
@@ -60,5 +60,15 @@ public class UserController {
     }
 
     // 비밀번호 변경
+    @PostMapping("/me/pw")
+    public ApiResponse<?> updatePassword(
+            @Schema(hidden = true) @AuthenticationPrincipal String userId,
+            @RequestBody @Valid UserDTO.UpdatePassWorddRequest request
+
+    ) {
+        var uid = Long.parseLong(userId);
+        authService.updatePassWord(uid, request.getPassword());
+        return ApiResponse.onSuccessWithoutResult();
+    }
 
 }

--- a/src/main/java/com/eyedia/eyedia/controller/UserController.java
+++ b/src/main/java/com/eyedia/eyedia/controller/UserController.java
@@ -63,7 +63,7 @@ public class UserController {
     @PostMapping("/me/pw")
     public ApiResponse<?> updatePassword(
             @Schema(hidden = true) @AuthenticationPrincipal String userId,
-            @RequestBody @Valid UserDTO.UpdatePassWorddRequest request
+            @RequestBody @Valid UserDTO.UpdatePassWordRequest request
 
     ) {
         var uid = Long.parseLong(userId);

--- a/src/main/java/com/eyedia/eyedia/controller/UserController.java
+++ b/src/main/java/com/eyedia/eyedia/controller/UserController.java
@@ -7,10 +7,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1/users")
@@ -35,7 +32,7 @@ public class UserController {
     // 유저 정보 변경
 
     // 아이디 변경
-    @PostMapping("/me/login-id")
+    @PatchMapping("/me/login-id")
     public ApiResponse<?> updateLoginId(
             @Schema(hidden = true) @AuthenticationPrincipal String userId,
             @RequestBody @Valid UserDTO.UpdateLoginIdRequest request
@@ -48,7 +45,7 @@ public class UserController {
     }
 
     // 닉네임 변경
-    @PostMapping("/me/nickname")
+    @PatchMapping("/me/nickname")
     public ApiResponse<?> updateNickName(
             @Schema(hidden = true) @AuthenticationPrincipal String userId,
             @RequestBody @Valid UserDTO.UpdateNickNamequest request
@@ -60,7 +57,7 @@ public class UserController {
     }
 
     // 비밀번호 변경
-    @PostMapping("/me/pw")
+    @PatchMapping("/me/pw")
     public ApiResponse<?> updatePassword(
             @Schema(hidden = true) @AuthenticationPrincipal String userId,
             @RequestBody @Valid UserDTO.UpdatePassWordRequest request

--- a/src/main/java/com/eyedia/eyedia/dto/UserDTO.java
+++ b/src/main/java/com/eyedia/eyedia/dto/UserDTO.java
@@ -57,7 +57,7 @@ public class UserDTO {
     @Getter
     @CheckPassWord(password = "password", confirmPassword = "confirmPassword")
     @AllArgsConstructor(access = AccessLevel.PROTECTED)
-    public static class UpdatePassWorddRequest {
+    public static class UpdatePassWordRequest {
 
         @NotBlank(message = "비밀번호는 필수입니다.")
         private String password;

--- a/src/main/java/com/eyedia/eyedia/dto/UserDTO.java
+++ b/src/main/java/com/eyedia/eyedia/dto/UserDTO.java
@@ -2,6 +2,7 @@ package com.eyedia.eyedia.dto;
 
 import com.eyedia.eyedia.global.validation.annotation.CheckLoginId;
 import com.eyedia.eyedia.global.validation.annotation.CheckNickName;
+import com.eyedia.eyedia.global.validation.annotation.CheckPassWord;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -50,5 +51,15 @@ public class UserDTO {
 
         @CheckLoginId
         private String loginId;
+    }
+
+    @Getter
+    @AllArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class UpdatePassWorddRequest {
+
+        @CheckPassWord
+        private String password;
+        private String verify_password;
+
     }
 }

--- a/src/main/java/com/eyedia/eyedia/dto/UserDTO.java
+++ b/src/main/java/com/eyedia/eyedia/dto/UserDTO.java
@@ -3,6 +3,7 @@ package com.eyedia.eyedia.dto;
 import com.eyedia.eyedia.global.validation.annotation.CheckLoginId;
 import com.eyedia.eyedia.global.validation.annotation.CheckNickName;
 import com.eyedia.eyedia.global.validation.annotation.CheckPassWord;
+import jakarta.validation.constraints.NotBlank;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -54,12 +55,14 @@ public class UserDTO {
     }
 
     @Getter
+    @CheckPassWord(password = "password", confirmPassword = "confirmPassword")
     @AllArgsConstructor(access = AccessLevel.PROTECTED)
     public static class UpdatePassWorddRequest {
 
-        @CheckPassWord
+        @NotBlank(message = "비밀번호는 필수입니다.")
         private String password;
-        private String verify_password;
+        @NotBlank(message = "비밀번호 확인은 필수입니다.")
+        private String confirmPassword;
 
     }
 }

--- a/src/main/java/com/eyedia/eyedia/global/error/exception/ExceptionAdvice.java
+++ b/src/main/java/com/eyedia/eyedia/global/error/exception/ExceptionAdvice.java
@@ -28,14 +28,18 @@ public class ExceptionAdvice {
         Map<String, String> errors = new HashMap<>();
         String errorCode = ErrorStatus._BAD_REQUEST.getCode(); // 기본값
         String errorMessage = ErrorStatus._BAD_REQUEST.getMessage();
+        ErrorStatus resolved = null; // 처음에 생긴 예외를 처리
 
         for (FieldError fieldError : e.getBindingResult().getFieldErrors()) {
             String msg = fieldError.getDefaultMessage();
 
             ErrorStatus status = ErrorStatus.fromCode(msg); // ← name으로 매핑
             if (status != null) {
-                errorCode = status.getCode();
-                errorMessage = status.getMessage();
+                if(resolved == null) {
+                    errorCode = status.getCode();
+                    errorMessage = status.getMessage();
+                    resolved = status;
+                }
                 errors.put(fieldError.getField(), status.getMessage());
             } else {
                 errors.put(fieldError.getField(), msg); // 일반 메시지

--- a/src/main/java/com/eyedia/eyedia/global/error/exception/ExceptionAdvice.java
+++ b/src/main/java/com/eyedia/eyedia/global/error/exception/ExceptionAdvice.java
@@ -8,6 +8,7 @@ import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
+import org.springframework.validation.ObjectError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -25,12 +26,38 @@ public class ExceptionAdvice {
     @ExceptionHandler(MethodArgumentNotValidException.class)
     protected ResponseEntity<?> handleMethodArgumentNotValid(MethodArgumentNotValidException e) {
         Map<String, String> errors = new HashMap<>();
+        String errorCode = ErrorStatus._BAD_REQUEST.getCode(); // 기본값
+        String errorMessage = ErrorStatus._BAD_REQUEST.getMessage();
+
         for (FieldError fieldError : e.getBindingResult().getFieldErrors()) {
-            errors.put(fieldError.getField(), fieldError.getDefaultMessage());
+            String msg = fieldError.getDefaultMessage();
+
+            ErrorStatus status = ErrorStatus.fromCode(msg); // ← name으로 매핑
+            if (status != null) {
+                errorCode = status.getCode();
+                errorMessage = status.getMessage();
+                errors.put(fieldError.getField(), status.getMessage());
+            } else {
+                errors.put(fieldError.getField(), msg); // 일반 메시지
+            }
         }
+
+        for (ObjectError globalError : e.getBindingResult().getGlobalErrors()) {
+            String msg = globalError.getDefaultMessage();
+
+            ErrorStatus status = ErrorStatus.fromCode(msg);
+            if (status != null) {
+                errorCode = status.getCode();
+                errorMessage = status.getMessage();
+                errors.put(globalError.getObjectName(), status.getMessage());
+            } else {
+                errors.put(globalError.getObjectName(), msg);
+            }
+        }
+
         return ResponseEntity
                 .badRequest()
-                .body(ApiResponse.onFailure(ErrorStatus._BAD_REQUEST.getCode(), "Validation Error", errors));
+                .body(ApiResponse.onFailure(errorCode, errorMessage, errors));
     }
 
     /**

--- a/src/main/java/com/eyedia/eyedia/global/error/status/ErrorStatus.java
+++ b/src/main/java/com/eyedia/eyedia/global/error/status/ErrorStatus.java
@@ -38,10 +38,11 @@ public enum ErrorStatus implements BaseErrorCode {
     // 사용자 관련
     USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER404", "해당하는 유저 정보가 없습니다."),
     WRONG_PASSWORD(HttpStatus.BAD_REQUEST, "USER403", "비밀번호가 틀렸습니다."),
+    ALREADY_USER_PASSWORD_SAME(HttpStatus.BAD_REQUEST, "USER408", "비밀번호가 틀렸습니다."),
     ALREADY_USER_ID_EXISTS(HttpStatus.BAD_REQUEST, "USER401", "이미 존재하는 아이디입니다."),
     ALREADY_USER_ID_SAME(HttpStatus.BAD_REQUEST, "USER406", "사용자의 아이디와 동일합니다."),
     ALREADY_USER_NAME_EXISTS(HttpStatus.BAD_REQUEST, "USER405", "이미 존재하는 닉네임입니다."),
-    ALREADY_USER_NAME_SAME(HttpStatus.BAD_REQUEST, "USER405", "사용자의 닉네임과 동일합니다."),
+    ALREADY_USER_NAME_SAME(HttpStatus.BAD_REQUEST, "USER407", "사용자의 비밀번호와 동일합니다."),
 
     // 즐겨찾기 관련
     ALREADY_BOOKMARK_EXISTS(HttpStatus.BAD_REQUEST, "BOOKMARK405", "이미 즐겨찾기되었습니다."),

--- a/src/main/java/com/eyedia/eyedia/global/error/status/ErrorStatus.java
+++ b/src/main/java/com/eyedia/eyedia/global/error/status/ErrorStatus.java
@@ -38,11 +38,11 @@ public enum ErrorStatus implements BaseErrorCode {
     // 사용자 관련
     USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER404", "해당하는 유저 정보가 없습니다."),
     WRONG_PASSWORD(HttpStatus.BAD_REQUEST, "USER403", "비밀번호가 틀렸습니다."),
-    ALREADY_USER_PASSWORD_SAME(HttpStatus.BAD_REQUEST, "USER408", "비밀번호가 틀렸습니다."),
+    ALREADY_USER_PASSWORD_SAME(HttpStatus.BAD_REQUEST, "USER408", "사용자의 현재 비밀번호와 동일합니다."),
     ALREADY_USER_ID_EXISTS(HttpStatus.BAD_REQUEST, "USER401", "이미 존재하는 아이디입니다."),
     ALREADY_USER_ID_SAME(HttpStatus.BAD_REQUEST, "USER406", "사용자의 아이디와 동일합니다."),
     ALREADY_USER_NAME_EXISTS(HttpStatus.BAD_REQUEST, "USER405", "이미 존재하는 닉네임입니다."),
-    ALREADY_USER_NAME_SAME(HttpStatus.BAD_REQUEST, "USER407", "사용자의 비밀번호와 동일합니다."),
+    ALREADY_USER_NAME_SAME(HttpStatus.BAD_REQUEST, "USER407", "사용자의 닉네임과 동일합니다."),
 
     // 즐겨찾기 관련
     ALREADY_BOOKMARK_EXISTS(HttpStatus.BAD_REQUEST, "BOOKMARK405", "이미 즐겨찾기되었습니다."),
@@ -71,5 +71,13 @@ public enum ErrorStatus implements BaseErrorCode {
                 .isSuccess(false)
                 .httpStatus(httpStatus)
                 .build();
+    }
+    public static ErrorStatus fromCode(String code) {
+        for (ErrorStatus status : values()) {
+            if (status.name().equals(code)) {
+                return status;
+            }
+        }
+        return null;
     }
 }

--- a/src/main/java/com/eyedia/eyedia/global/validation/annotation/CheckPassWord.java
+++ b/src/main/java/com/eyedia/eyedia/global/validation/annotation/CheckPassWord.java
@@ -1,4 +1,21 @@
 package com.eyedia.eyedia.global.validation.annotation;
 
+import com.eyedia.eyedia.global.validation.validator.CheckPassWordValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = CheckPassWordValidator.class)
+@Target({ElementType.TYPE}) // 클래스 단위. 단순 타입은 FIELD 사용
+@Retention(RetentionPolicy.RUNTIME)
 public @interface CheckPassWord {
+
+    String message() default "비밀번호를 바꿀 수 없습니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+
+    // 비교할 필드
+    String password();
+    String confirmPassword();
 }

--- a/src/main/java/com/eyedia/eyedia/global/validation/validator/CheckLoginIdValidator.java
+++ b/src/main/java/com/eyedia/eyedia/global/validation/validator/CheckLoginIdValidator.java
@@ -32,7 +32,7 @@ public class CheckLoginIdValidator implements ConstraintValidator<CheckLoginId, 
         boolean isExists = userRepository.existsByIdAndUsersIdNot(loginId, currentUserId);
         if (isExists) {
             context.disableDefaultConstraintViolation();
-            context.buildConstraintViolationWithTemplate(ErrorStatus.ALREADY_USER_ID_EXISTS.getMessage())
+            context.buildConstraintViolationWithTemplate(ErrorStatus.ALREADY_USER_ID_EXISTS.name())
                     .addConstraintViolation();
             return false;
 
@@ -40,7 +40,7 @@ public class CheckLoginIdValidator implements ConstraintValidator<CheckLoginId, 
         boolean isEquals = userRepository.existsByIdAndUsersId(loginId, currentUserId);
         if(isEquals) {
             context.disableDefaultConstraintViolation();
-            context.buildConstraintViolationWithTemplate(ErrorStatus.ALREADY_USER_ID_SAME.getMessage())
+            context.buildConstraintViolationWithTemplate(ErrorStatus.ALREADY_USER_ID_SAME.name())
                     .addConstraintViolation();
             return false;
         }

--- a/src/main/java/com/eyedia/eyedia/global/validation/validator/CheckNickNameValidator.java
+++ b/src/main/java/com/eyedia/eyedia/global/validation/validator/CheckNickNameValidator.java
@@ -36,14 +36,14 @@ public class CheckNickNameValidator implements ConstraintValidator<CheckNickName
         boolean isExists = userRepository.existsByNameAndUsersIdNot(nickname, currentUserId);
         if (isExists) {
             context.disableDefaultConstraintViolation();
-            context.buildConstraintViolationWithTemplate(ErrorStatus.ALREADY_USER_NAME_EXISTS.getMessage())
+            context.buildConstraintViolationWithTemplate(ErrorStatus.ALREADY_USER_NAME_EXISTS.name())
                     .addConstraintViolation();
             return false;
         }
         boolean isEquals = userRepository.existsByNameAndUsersId(nickname, currentUserId);
         if(isEquals) {
             context.disableDefaultConstraintViolation();
-            context.buildConstraintViolationWithTemplate(ErrorStatus.ALREADY_USER_NAME_SAME.getMessage())
+            context.buildConstraintViolationWithTemplate(ErrorStatus.ALREADY_USER_NAME_SAME.name())
                     .addConstraintViolation();
             return false;
         }

--- a/src/main/java/com/eyedia/eyedia/global/validation/validator/CheckPassWordValidator.java
+++ b/src/main/java/com/eyedia/eyedia/global/validation/validator/CheckPassWordValidator.java
@@ -1,0 +1,71 @@
+package com.eyedia.eyedia.global.validation.validator;
+
+import com.eyedia.eyedia.global.error.status.ErrorStatus;
+import com.eyedia.eyedia.global.validation.annotation.CheckPassWord;
+import com.eyedia.eyedia.repository.UserRepository;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import java.lang.reflect.Field;
+
+@Component
+@RequiredArgsConstructor
+public class CheckPassWordValidator implements ConstraintValidator<CheckPassWord, Object> {
+    private final UserRepository userRepository;
+
+    // Field로 사용
+    private String passwordField;
+    private String confirmPasswordField;
+    // 초기화하여 변수 여러개를 받아와야 함
+    @Override
+    public void initialize(CheckPassWord constraintAnnotation) {
+        this.passwordField = constraintAnnotation.password();
+        this.confirmPasswordField = constraintAnnotation.confirmPassword();
+    }
+
+    public boolean isValid(Object value, ConstraintValidatorContext context) {
+        if (value == null) return true;
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || !(auth.getPrincipal() instanceof String userDetails)) {
+            return true;
+        }
+
+        Long currentUserId = Long.parseLong(userDetails);
+
+        try {
+            Field password = value.getClass().getDeclaredField(passwordField);
+            Field confirmPassword = value.getClass().getDeclaredField(confirmPasswordField);
+
+            password.setAccessible(true);
+            confirmPassword.setAccessible(true);
+
+            // dto 값을 꺼내온다
+            Object passValue = password.get(value);
+            Object confirmValue = confirmPassword.get(value);
+
+            if(!password.equals(confirmPassword)) {
+                context.disableDefaultConstraintViolation();
+                context.buildConstraintViolationWithTemplate(ErrorStatus.WRONG_PASSWORD.getMessage())
+                        .addConstraintViolation();
+                return false;
+
+            }
+            // 이미 같은 비밀번호 일 시
+            if(userRepository.getUserByUsersId(currentUserId).equals(passwordField)) {
+                context.disableDefaultConstraintViolation();
+                context.buildConstraintViolationWithTemplate(ErrorStatus.ALREADY_USER_PASSWORD_SAME.getMessage())
+                        .addConstraintViolation();
+                return false;
+
+            }
+
+            return passValue.equals(confirmValue);
+        } catch (Exception e) {
+            return false; // 필드 못 찾거나 예외 발생 시 invalid
+        }
+    }
+}

--- a/src/main/java/com/eyedia/eyedia/global/validation/validator/CheckPassWordValidator.java
+++ b/src/main/java/com/eyedia/eyedia/global/validation/validator/CheckPassWordValidator.java
@@ -1,5 +1,6 @@
 package com.eyedia.eyedia.global.validation.validator;
 
+import com.eyedia.eyedia.dto.UserDTO;
 import com.eyedia.eyedia.global.error.status.ErrorStatus;
 import com.eyedia.eyedia.global.validation.annotation.CheckPassWord;
 import com.eyedia.eyedia.repository.UserRepository;
@@ -8,23 +9,18 @@ import jakarta.validation.ConstraintValidatorContext;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
-import java.lang.reflect.Field;
 
 @Component
 @RequiredArgsConstructor
 public class CheckPassWordValidator implements ConstraintValidator<CheckPassWord, Object> {
     private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
 
     // Field로 사용
-    private String passwordField;
-    private String confirmPasswordField;
-    // 초기화하여 변수 여러개를 받아와야 함
-    @Override
-    public void initialize(CheckPassWord constraintAnnotation) {
-        this.passwordField = constraintAnnotation.password();
-        this.confirmPasswordField = constraintAnnotation.confirmPassword();
-    }
+    private String passValue;
+    private String confirmValue;
 
     public boolean isValid(Object value, ConstraintValidatorContext context) {
         if (value == null) return true;
@@ -37,35 +33,35 @@ public class CheckPassWordValidator implements ConstraintValidator<CheckPassWord
         Long currentUserId = Long.parseLong(userDetails);
 
         try {
-            Field password = value.getClass().getDeclaredField(passwordField);
-            Field confirmPassword = value.getClass().getDeclaredField(confirmPasswordField);
+            if (value instanceof UserDTO.UpdatePassWordRequest dto) {
+                passValue = dto.getPassword();
+                confirmValue = dto.getConfirmPassword();
+            }
 
-            password.setAccessible(true);
-            confirmPassword.setAccessible(true);
-
-            // dto 값을 꺼내온다
-            Object passValue = password.get(value);
-            Object confirmValue = confirmPassword.get(value);
-
-            if(!password.equals(confirmPassword)) {
+            // 비밀번호와 확인비밀번호가 같은 지 확인
+            if(!passValue.equals(confirmValue)) {
                 context.disableDefaultConstraintViolation();
-                context.buildConstraintViolationWithTemplate(ErrorStatus.WRONG_PASSWORD.getMessage())
+                context.buildConstraintViolationWithTemplate(ErrorStatus.WRONG_PASSWORD.name())
                         .addConstraintViolation();
                 return false;
 
             }
             // 이미 같은 비밀번호 일 시
-            if(userRepository.getUserByUsersId(currentUserId).equals(passwordField)) {
+            // 입력한_평문_비밀번호, DB에_저장된_암호화된_비밀번호 순으로
+            if(passwordEncoder.matches(passValue, userRepository.getUserByUsersId(currentUserId).getPw())) {
                 context.disableDefaultConstraintViolation();
-                context.buildConstraintViolationWithTemplate(ErrorStatus.ALREADY_USER_PASSWORD_SAME.getMessage())
+                context.buildConstraintViolationWithTemplate(ErrorStatus.ALREADY_USER_PASSWORD_SAME.name())
                         .addConstraintViolation();
                 return false;
 
             }
 
-            return passValue.equals(confirmValue);
+            return true;
         } catch (Exception e) {
-            return false; // 필드 못 찾거나 예외 발생 시 invalid
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate("비밀번호 검증 중 서버 오류가 발생했습니다.")
+                    .addConstraintViolation();
+            return false;
         }
     }
 }

--- a/src/main/java/com/eyedia/eyedia/repository/UserRepository.java
+++ b/src/main/java/com/eyedia/eyedia/repository/UserRepository.java
@@ -37,4 +37,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("update User u set u.pw = :pw where u.usersId = :usersId")
     int updatePassWord(@Param("usersId") Long usersId, @Param("pw") String password);
+
 }

--- a/src/main/java/com/eyedia/eyedia/repository/UserRepository.java
+++ b/src/main/java/com/eyedia/eyedia/repository/UserRepository.java
@@ -35,7 +35,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     int updateNickname(@Param("usersId") Long usersId, @Param("nickname") String nickname);
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
-    @Query("update User u set u.pw = :pw where u.usersId = :usersId")
-    int updatePassWord(@Param("usersId") Long usersId, @Param("pw") String password);
+    @Query("update User u set u.pw = :passWord where u.usersId = :usersId")
+    int updatePassWord(@Param("usersId") Long usersId, @Param("passWord") String passWord);
 
 }

--- a/src/main/java/com/eyedia/eyedia/repository/UserRepository.java
+++ b/src/main/java/com/eyedia/eyedia/repository/UserRepository.java
@@ -33,4 +33,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("update User u set u.name = :nickname where u.usersId = :usersId")
     int updateNickname(@Param("usersId") Long usersId, @Param("nickname") String nickname);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("update User u set u.pw = :pw where u.usersId = :usersId")
+    int updatePassWord(@Param("usersId") Long usersId, @Param("pw") String password);
 }

--- a/src/main/java/com/eyedia/eyedia/service/impl/AuthService.java
+++ b/src/main/java/com/eyedia/eyedia/service/impl/AuthService.java
@@ -102,14 +102,23 @@ public class AuthService {
     }
 
     public void updateLoginId(long uid, String loginId) {
-        userRepository.updateLoginId(uid, loginId);
+        int updated = userRepository.updateLoginId(uid, loginId);
+        if(updated == 0) {
+            throw new GeneralException(ErrorStatus.USER_NOT_FOUND);
+        }
     }
 
     public void updateNickName(long uid, String nickname) {
-        userRepository.updateNickname(uid, nickname);
+        int updated = userRepository.updateNickname(uid, nickname);
+        if(updated == 0) {
+            throw new GeneralException(ErrorStatus.USER_NOT_FOUND);
+        }
     }
 
     public void updatePassWord(long uid, String passWord) {
-        userRepository.updatePassWord(uid, passwordEncoder.encode(passWord));
+        int updated = userRepository.updatePassWord(uid, passwordEncoder.encode(passWord));
+        if(updated == 0) {
+            throw new GeneralException(ErrorStatus.USER_NOT_FOUND);
+        }
     }
 }

--- a/src/main/java/com/eyedia/eyedia/service/impl/AuthService.java
+++ b/src/main/java/com/eyedia/eyedia/service/impl/AuthService.java
@@ -110,6 +110,6 @@ public class AuthService {
     }
 
     public void updatePassWord(long uid, String passWord) {
-        userRepository.updatePassWord(uid, passWord);
+        userRepository.updatePassWord(uid, passwordEncoder.encode(passWord));
     }
 }

--- a/src/main/java/com/eyedia/eyedia/service/impl/AuthService.java
+++ b/src/main/java/com/eyedia/eyedia/service/impl/AuthService.java
@@ -108,4 +108,8 @@ public class AuthService {
     public void updateNickName(long uid, String nickname) {
         userRepository.updateNickname(uid, nickname);
     }
+
+    public void updatePassWord(long uid, String passWord) {
+        userRepository.updatePassWord(uid, passWord);
+    }
 }


### PR DESCRIPTION
# 💡 PR Summary - <!--{ 작업 내용 }-->비밀번호 변경 유효성 검사 및 커스텀 에러 응답 처리 개선
<!-- 어떤 작업에 대한 PR 인지 위 주석에 적어주세요 -->

### 📝 Description

---
<!-- 어떤 작업을 했는지 간단하게 적어주세요 -->
작업 사항
- `@CheckPassWord` 커스텀 유효성 검사 개선
- 유효성 검사 실패 시 `ErrorStatus` 기반 에러 메시지 및 코드 응답
- 클래스 레벨 유효성 검사 오류도 클라이언트에 필드 기반으로 응답되도록 개선


#### 1. `@CheckPassWordValidator` 개선
- 기존 비밀번호와 동일한지 확인할 때 `PasswordEncoder.matches(입력값, 기존 암호화된 비밀번호)` 순서 오류 수정
- 유효성 실패 시 `context.buildConstraintViolationWithTemplate(ErrorStatus.XXX.name())` 형식으로 에러코드 전달

#### 2. `ErrorStatus` Enum 기능 확장
- `name()`으로 비교할 수 있도록 메시지 대신 enum name을 전달하도록 수정
- `fromCode(String)` 메서드 추가 → Validator에서 전달된 코드 문자열로 `ErrorStatus` 역매핑 가능

#### 3. `@ExceptionHandler(MethodArgumentNotValidException.class)` 개선
- 기존에는 `getFieldErrors()`만 처리 → `getGlobalErrors()`도 함께 수집하도록 개선
- 메시지에 포함된 `ErrorStatus.name()`을 기반으로 코드/메시지 자동 추출
- `ApiResponse` 응답 구조에 `"code"`, `"message"`, `"result"`가 들어가도록 개선
### 🌲 Working Branch

---
<!-- 예시) feature/user -->
작업 브랜치
- feat/85-user
### 📖 Related Issues

---
<!-- 예시) #1 -->
이슈 번호
- #85 

### 📚 Etc

---
<!-- 작업 중 특이사항이 생기면 적어주세요 -->
특이사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can update their password from their account (with confirmation).
  * Login ID and nickname updates now use PATCH semantics.

* **Bug Fixes**
  * Validation errors map to specific standardized error codes and messages.
  * Prevents setting a new password identical to the current one, with a clear error message.
  * Improved nickname duplication response code for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->