### PR TITLE
Feat: 취향 기반 전시 추천 리스트 반환 

### DIFF
--- a/src/main/java/com/eyedia/eyedia/controller/RecommendationController.java
+++ b/src/main/java/com/eyedia/eyedia/controller/RecommendationController.java
@@ -1,0 +1,35 @@
+package com.eyedia.eyedia.controller;
+
+import com.eyedia.eyedia.dto.RecommendationDTO;
+import com.eyedia.eyedia.service.RecommendationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Recommendations")
+@RestController
+@RequestMapping("/api/v1/recommendations")
+@RequiredArgsConstructor
+public class RecommendationController {
+    private final RecommendationService recommendationService;
+
+    @Operation(
+            summary = "내 키워드 조회",
+            description = "회원가입 시 사용자가 선택한 ExhibitionCategory 키워드 배열을 반환합니다."
+    )
+    @ApiResponse(responseCode = "200", description = "OK")
+    @GetMapping("/keywords")
+    public ResponseEntity<RecommendationDTO> getMyKeywords(
+            @Parameter(hidden = true) @AuthenticationPrincipal String usersId
+    ) {
+        return ResponseEntity.ok(recommendationService.getMyKeywords(Long.valueOf(usersId)));
+    }
+}

--- a/src/main/java/com/eyedia/eyedia/controller/RecommendationController.java
+++ b/src/main/java/com/eyedia/eyedia/controller/RecommendationController.java
@@ -1,6 +1,8 @@
 package com.eyedia.eyedia.controller;
 
+import com.eyedia.eyedia.domain.enums.ExhibitionCategory;
 import com.eyedia.eyedia.dto.RecommendationDTO;
+import com.eyedia.eyedia.dto.RecommendedExhibitionsResponse;
 import com.eyedia.eyedia.service.RecommendationService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -12,7 +14,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @Tag(name = "Recommendations")
 @RestController
@@ -31,5 +36,20 @@ public class RecommendationController {
             @Parameter(hidden = true) @AuthenticationPrincipal String usersId
     ) {
         return ResponseEntity.ok(recommendationService.getMyKeywords(Long.valueOf(usersId)));
+    }
+
+    @Operation(
+            summary = "사용자 맞춤 전시회 추천",
+            description = "회원가입 시 사용자가 선택한 ExhibitionCategory 키워드에 맞는 전시 리스트를 반환합니다."
+    )
+    @ApiResponse(responseCode = "200", description = "OK")
+    @GetMapping("/exhibitions")
+    public ResponseEntity<List<RecommendedExhibitionsResponse>> getExhibitions(
+            @Parameter(hidden = true) @AuthenticationPrincipal String usersId,
+            @RequestParam(defaultValue = "10") int size
+    ){
+        return ResponseEntity.ok(
+                recommendationService.getMyRecommendedExhibitions(Long.valueOf(usersId), size)
+        );
     }
 }

--- a/src/main/java/com/eyedia/eyedia/controller/ScrapController.java
+++ b/src/main/java/com/eyedia/eyedia/controller/ScrapController.java
@@ -75,12 +75,12 @@ public class ScrapController {
                 """
     )
     public ResponseEntity<Page<ScrapResponseDto>> getMyScrapList(
-            @Parameter(hidden = true) @AuthenticationPrincipal String userId,
+            Principal principal,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "5") int limit,
             @RequestParam(defaultValue = "recent") String sort
     ) {
-        Long uid = Long.parseLong(userId);
+        Long uid = Long.parseLong(principal.getName());
 
         Sort.Direction direction;
         String sortProperty = "date"; // 기본 정렬 컬럼

--- a/src/main/java/com/eyedia/eyedia/domain/Exhibition.java
+++ b/src/main/java/com/eyedia/eyedia/domain/Exhibition.java
@@ -40,8 +40,10 @@ public class Exhibition extends BaseEntity {
     private Integer visitCount;
     private String artist;
 
-    @Enumerated(EnumType.STRING)
-    private ExhibitionCategory category;
+     @Enumerated(EnumType.STRING)
+     private ExhibitionCategory category;
+
+   // private String category;
 
     private String location;
 
@@ -61,5 +63,6 @@ public class Exhibition extends BaseEntity {
 
     @OneToMany(mappedBy = "exhibition", cascade = CascadeType.ALL)
     private List<Visit> visits = new ArrayList<>();
+
 }
 

--- a/src/main/java/com/eyedia/eyedia/domain/User.java
+++ b/src/main/java/com/eyedia/eyedia/domain/User.java
@@ -3,6 +3,7 @@ package com.eyedia.eyedia.domain;
 import com.eyedia.eyedia.domain.badge.Badge;
 import com.eyedia.eyedia.domain.badge.UserBadgeAward;
 import com.eyedia.eyedia.domain.common.BaseEntity;
+import com.eyedia.eyedia.domain.enums.ExhibitionCategory;
 import com.eyedia.eyedia.domain.enums.Gender;
 import com.eyedia.eyedia.domain.mapping.Bookmark;
 import com.eyedia.eyedia.domain.mapping.Visit;
@@ -66,6 +67,26 @@ public class User extends BaseEntity {
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private List<UserBadgeAward> userBadgeAwards = new ArrayList<>();
+
+    // --- 회원가입 시 선택한 이넘 키워드 보관 ---
+    @ElementCollection(fetch = FetchType.LAZY)
+    @CollectionTable(
+            name = "user_selected_keywords",
+            joinColumns = @JoinColumn(name = "users_id") // FK 컬럼명 명시
+    )
+    @Enumerated(EnumType.STRING)
+    @Column(name = "keyword", length = 32, nullable = false)
+    @Builder.Default
+    private java.util.Set<ExhibitionCategory> selectedKeywords = new java.util.HashSet<>();
+
+    // 편의 메서드
+    public void setSelectedKeywords(java.util.Collection<ExhibitionCategory> keywords) {
+        this.selectedKeywords.clear();
+        if (keywords != null) this.selectedKeywords.addAll(keywords);
+    }
+    public void addKeyword(ExhibitionCategory k) { this.selectedKeywords.add(k); }
+    public void removeKeyword(ExhibitionCategory k) { this.selectedKeywords.remove(k); }
+
 
     public void setIsFirstLogin(boolean isFirstLogin) {
         this.isFirstLogin = isFirstLogin;

--- a/src/main/java/com/eyedia/eyedia/dto/RecommendationDTO.java
+++ b/src/main/java/com/eyedia/eyedia/dto/RecommendationDTO.java
@@ -1,0 +1,9 @@
+package com.eyedia.eyedia.dto;
+
+import com.eyedia.eyedia.domain.enums.ExhibitionCategory;
+import lombok.*;
+
+@Getter @AllArgsConstructor @NoArgsConstructor @Builder
+public class RecommendationDTO {
+    private java.util.List<ExhibitionCategory> keywords;
+}

--- a/src/main/java/com/eyedia/eyedia/dto/RecommendedExhibitionsResponse.java
+++ b/src/main/java/com/eyedia/eyedia/dto/RecommendedExhibitionsResponse.java
@@ -1,0 +1,21 @@
+package com.eyedia.eyedia.dto;
+
+import lombok.*;
+import java.util.List;
+
+@Getter @Setter @Builder
+@AllArgsConstructor @NoArgsConstructor
+public class RecommendedExhibitionsResponse {
+    private String keyword; // 예: "BRIGHT"
+    private List<Item> exhibitions;
+
+    @Getter @Setter @Builder
+    @AllArgsConstructor @NoArgsConstructor
+    public static class Item {
+        private Long id;
+        private String title;
+        private String artist;
+        private String location;
+        private String thumbnailUrl;
+    }
+}

--- a/src/main/java/com/eyedia/eyedia/dto/UserSignupDTO.java
+++ b/src/main/java/com/eyedia/eyedia/dto/UserSignupDTO.java
@@ -1,7 +1,10 @@
 package com.eyedia.eyedia.dto;
 
+import com.eyedia.eyedia.domain.enums.ExhibitionCategory;
 import lombok.Getter;
 import lombok.Setter;
+
+import java.util.List;
 
 @Getter
 @Setter
@@ -15,4 +18,5 @@ public class UserSignupDTO {
     private String pw;
     private String currentLocation;
 
+    private List<ExhibitionCategory> keywords;
 }

--- a/src/main/java/com/eyedia/eyedia/repository/ExhibitionRepository.java
+++ b/src/main/java/com/eyedia/eyedia/repository/ExhibitionRepository.java
@@ -1,6 +1,7 @@
 package com.eyedia.eyedia.repository;
 
 import com.eyedia.eyedia.domain.Exhibition;
+import com.eyedia.eyedia.domain.enums.ExhibitionCategory;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -49,5 +50,7 @@ public interface ExhibitionRepository extends JpaRepository<Exhibition, Long> {
     List<Exhibition> findByTitleContainingIgnoreCaseOrGalleryContainingIgnoreCase(
             String titlePart, String galleryPart, Pageable pageable
     );
+
+    List<Exhibition> findByCategoryOrderByVisitCountDesc(ExhibitionCategory category, Pageable pageable);
 
 }

--- a/src/main/java/com/eyedia/eyedia/service/RecommendationService.java
+++ b/src/main/java/com/eyedia/eyedia/service/RecommendationService.java
@@ -1,0 +1,22 @@
+package com.eyedia.eyedia.service;
+
+import com.eyedia.eyedia.dto.RecommendationDTO;
+import com.eyedia.eyedia.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RecommendationService {
+    private final UserRepository userRepository;
+
+    public RecommendationDTO getMyKeywords(Long usersId) {
+        var user = userRepository.getUserByUsersId(usersId);
+
+        return RecommendationDTO.builder()
+                .keywords(user.getSelectedKeywords().stream().toList())
+                .build();
+    }
+}

--- a/src/main/java/com/eyedia/eyedia/service/RecommendationService.java
+++ b/src/main/java/com/eyedia/eyedia/service/RecommendationService.java
@@ -1,16 +1,25 @@
 package com.eyedia.eyedia.service;
 
+import com.eyedia.eyedia.domain.User;
+import com.eyedia.eyedia.domain.enums.ExhibitionCategory;
 import com.eyedia.eyedia.dto.RecommendationDTO;
+import com.eyedia.eyedia.dto.RecommendedExhibitionsResponse;
+import com.eyedia.eyedia.repository.ExhibitionRepository;
 import com.eyedia.eyedia.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class RecommendationService {
     private final UserRepository userRepository;
+    private final ExhibitionRepository exhibitionRepository;
 
     public RecommendationDTO getMyKeywords(Long usersId) {
         var user = userRepository.getUserByUsersId(usersId);
@@ -18,5 +27,37 @@ public class RecommendationService {
         return RecommendationDTO.builder()
                 .keywords(user.getSelectedKeywords().stream().toList())
                 .build();
+    }
+
+    public List<RecommendedExhibitionsResponse> getMyRecommendedExhibitions(Long usersId, int size) {
+        User user = userRepository.getUserByUsersId(usersId);
+
+        var selected = user.getSelectedKeywords();
+        if (selected == null || selected.isEmpty()) {
+            return List.of(); // 아무 키워드도 없으면 빈 리스트
+        }
+
+        // 키워드마다 응답 생성
+        return selected.stream()
+                .map(category -> {
+                    var exhibitions = exhibitionRepository.findByCategoryOrderByVisitCountDesc(
+                            category, PageRequest.of(0, Math.max(size, 1)));
+
+                    var items = exhibitions.stream().map(e ->
+                            RecommendedExhibitionsResponse.Item.builder()
+                                    .id(e.getExhibitionsId())
+                                    .title(e.getTitle())
+                                    .artist(e.getArtist())
+                                    .location(e.getGallery() != null ? e.getGallery() : e.getLocation())
+                                    .thumbnailUrl(e.getPosterUrl())
+                                    .build()
+                    ).toList();
+
+                    return RecommendedExhibitionsResponse.builder()
+                            .keyword(category.name())
+                            .exhibitions(items)
+                            .build();
+                })
+                .toList();
     }
 }

--- a/src/main/java/com/eyedia/eyedia/service/impl/AuthService.java
+++ b/src/main/java/com/eyedia/eyedia/service/impl/AuthService.java
@@ -41,7 +41,7 @@ public class AuthService {
                 .pw(passwordEncoder.encode(dto.getPw()))
                 .currentLocation(dto.getCurrentLocation())
                 .build();
-
+        user.setSelectedKeywords(dto.getKeywords());
         userRepository.save(user);
     }
 


### PR DESCRIPTION
# 💡 PR Summary - <!--{ 작업 내용 }-->취향 기반 전시 추천
<!-- 어떤 작업에 대한 PR 인지 위 주석에 적어주세요 -->
사용자가 회원가입 할 때 선택한 키워드들을 이용해 전시회 추천 

### 📝 Description

---
<!-- 어떤 작업을 했는지 간단하게 적어주세요 -->
작업 사항
- 회원가입 시 사용자 선호 keywords 받도록 수정
- 사용자가 선택한 keywords 조회 
- 사용자 맞춤 전시 리스트 반환 

### 🌲 Working Branch

---
<!-- 예시) feature/user -->
작업 브랜치 feat/90-preference-art-recommend

### 📖 Related Issues

---
<!-- 예시) #1 -->
이슈 번호 90


### 📚 Etc

---
<!-- 작업 중 특이사항이 생기면 적어주세요 -->
특이사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added personalized recommendations: authenticated users can retrieve their selected keywords and get recommended exhibitions per interest with an optional size limit.
  - Signup now supports submitting interest keywords to tailor future recommendations.
- Documentation
  - API documentation updated for the new recommendations endpoints to guide usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->