### PR TITLE
Feat:총 관람 전시 횟수 조회

### DIFF
--- a/src/main/java/com/eyedia/eyedia/controller/ExhibitionController.java
+++ b/src/main/java/com/eyedia/eyedia/controller/ExhibitionController.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -173,6 +174,38 @@ public class ExhibitionController {
         exhibitionCommandService.deleteBookmarkVisitedExhibitionByUser(uid, exhibitionId);
         return ApiResponse.onSuccessWithoutResult();
 
+    }
+
+    @Operation(
+            summary = "내가 방문한 전시 개수 조회",
+            description = "JWT 토큰을 통해 로그인한 사용자가 지금까지 방문한 전시의 개수(중복 제외)를 반환합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청 (userId 누락 등)"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패")
+    })
+    @GetMapping("/my/visited/count")
+    public ResponseEntity<CountResponse> getMyVisitedExhibitionCount(
+            @Schema(hidden = true) @AuthenticationPrincipal String userId
+    ) {
+
+        Long uid = Long.valueOf(userId);
+
+        long count = exhibitionService.getMyVisitedExhibitionCount(uid);
+        return ResponseEntity.ok(new CountResponse(count));
+    }
+
+    public static class CountResponse {
+        private long count;
+
+        public CountResponse(long count) {
+            this.count = count;
+        }
+
+        public long getCount() {
+            return count;
+        }
     }
 
 }

--- a/src/main/java/com/eyedia/eyedia/domain/enums/ExhibitionCategory.java
+++ b/src/main/java/com/eyedia/eyedia/domain/enums/ExhibitionCategory.java
@@ -1,6 +1,7 @@
 package com.eyedia.eyedia.domain.enums;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonValue;
 import lombok.Getter;
 
 @Getter

--- a/src/main/java/com/eyedia/eyedia/repository/VisitRepository.java
+++ b/src/main/java/com/eyedia/eyedia/repository/VisitRepository.java
@@ -11,6 +11,12 @@ import org.springframework.data.repository.query.Param;
 import java.time.LocalDateTime;
 
 public interface VisitRepository extends JpaRepository<Visit, Long> {
+
+    // 유저가 방문한 전시의 "개수" (중복 없이)
+    @Query("SELECT COUNT(DISTINCT v.exhibition.exhibitionsId) " +
+            "FROM Visit v WHERE v.user.usersId = :userId")
+    long countDistinctExhibitionsByUserId(@Param("userId") Long userId);
+
     // 사용자가 방문한 전시 목록 반환(distinct)
     @Query(
             value = """

--- a/src/main/java/com/eyedia/eyedia/service/ExhibitionQueryService.java
+++ b/src/main/java/com/eyedia/eyedia/service/ExhibitionQueryService.java
@@ -172,6 +172,8 @@ public class ExhibitionQueryService {
         return e.getStartDate().toLocalDate() + " ~ " + e.getEndDate().toLocalDate();
     }
 
-
-
+    public long getMyVisitedExhibitionCount(Long userId) {
+        if (userId == null) throw new IllegalArgumentException("userId must not be null");
+        return visitRepository.countDistinctExhibitionsByUserId(userId);
+    }
 }


### PR DESCRIPTION
# 💡 PR Summary - <!--{ 작업 내용 }-->총 관람 전시 횟수 조회
<!-- 어떤 작업에 대한 PR 인지 위 주석에 적어주세요 -->
총 관람 전시 횟수 반환 

### 📝 Description

---
<!-- 어떤 작업을 했는지 간단하게 적어주세요 -->
작업 사항

### 🌲 Working Branch

---
<!-- 예시) feature/user -->
작업 브랜치

### 📖 Related Issues

---
<!-- 예시) #1 -->
이슈 번호 96 


### 📚 Etc

---
<!-- 작업 중 특이사항이 생기면 적어주세요 -->
특이사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an authenticated API endpoint to get your total number of distinct exhibitions visited: GET /api/v1/exhibitions/my/visited/count. Returns a numeric count in the response body.
* **Documentation**
  * API docs updated to include the new endpoint with summary, description, required auth, and response codes (200/400/401), improving discoverability and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->