### PR TITLE
[Feat] 응시 영역 llm 응답 API 구현

### DIFF
--- a/src/main/java/com/eyedia/eyedia/config/SecurityConfig.java
+++ b/src/main/java/com/eyedia/eyedia/config/SecurityConfig.java
@@ -90,6 +90,7 @@ public class SecurityConfig {
                                 "/api/v1/scraps/**",
                                 "/tts/**",
                                 "/api/v1/events/detect",
+                                "/api/v1/events/detect-area",
                                 "/api/v1/chats/ask",
 
                                 // OAuth2 로그인 경로 허용

--- a/src/main/java/com/eyedia/eyedia/controller/ChatController.java
+++ b/src/main/java/com/eyedia/eyedia/controller/ChatController.java
@@ -17,7 +17,7 @@ public class ChatController {
 
     @MessageMapping("/chat.sendMessage")
     public void sendMessage(@Payload MessageDTO.ChatMessageDTO m, Principal principal) {
-        String room = "/room/user-" + principal.getName();
+        String room = "/room/" + m.getPaintingId();
         messagingTemplate.convertAndSendToUser(principal.getName(),room, m);
     }
 }

--- a/src/main/java/com/eyedia/eyedia/controller/DetectionEventController.java
+++ b/src/main/java/com/eyedia/eyedia/controller/DetectionEventController.java
@@ -1,19 +1,27 @@
 package com.eyedia.eyedia.controller;
 
+import com.eyedia.eyedia.domain.Message;
 import com.eyedia.eyedia.domain.Painting;
+import com.eyedia.eyedia.domain.enums.SenderType;
+import com.eyedia.eyedia.dto.DetectAreaRequestDTO;
 import com.eyedia.eyedia.dto.MessageDTO;
 import com.eyedia.eyedia.global.ApiResponse;
 import com.eyedia.eyedia.global.error.exception.GeneralException;
 import com.eyedia.eyedia.global.error.status.ErrorStatus;
 import com.eyedia.eyedia.global.error.status.SuccessStatus;
 import com.eyedia.eyedia.repository.ExhibitionRepository;
+import com.eyedia.eyedia.repository.MessageRepository;
 import com.eyedia.eyedia.repository.PaintingRepository;
+import com.eyedia.eyedia.service.DocentChatService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/api/v1/events")
@@ -23,6 +31,8 @@ public class DetectionEventController {
     private final SimpMessageSendingOperations messagingTemplate;
     private final PaintingRepository paintingRepository;
     private final ExhibitionRepository exhibitionRepository;
+    private final DocentChatService docentChatService;
+    private final MessageRepository messageRepository;
 
     @PostMapping("/detect")
     public ApiResponse<?> detect(@RequestBody Long artId) {
@@ -53,5 +63,57 @@ public class DetectionEventController {
             messagingTemplate.convertAndSend("/queue/events", message);
         }
         return ApiResponse.of(SuccessStatus._OK, message);
+    }
+
+    @PostMapping("/detect-area")
+    public ApiResponse<?> detectArea(@RequestBody DetectAreaRequestDTO request) {
+
+        List<String> descriptions = request.getList().stream()
+                .map(DetectAreaRequestDTO.CropItemDTO::getCropDescription)
+                .toList();
+
+        String combined = descriptions.stream()
+                .map(desc -> "- " + desc)
+                .collect(Collectors.joining("\n"));
+
+        List<Painting> paintings = paintingRepository.findByArtId(request.getArtId());
+
+        var answer = docentChatService.answer(
+                docentChatService.gazeAreaPrompt(
+                        paintings.get(0).getTitle(),
+                        request.getQ().get(0),
+                        combined));
+
+        MessageDTO.ChatAnswerDTO dto = null;
+        String imageUrl = "https://s3-eyedia.s3.ap-northeast-2.amazonaws.com/"
+                          + paintings.get(0).getExhibition().getExhibitionsId() + "/"
+                          + paintings.get(0).getArtId() + "/"
+                          + request.getQ().get(0) + ".jpg";
+
+        for (Painting painting : paintings) {
+            Message q = Message.builder()
+                    .sender(SenderType.USER)
+                    .painting(painting)
+                    .content(imageUrl)
+                    .build();
+            messageRepository.save(q);
+
+            Message a = Message.builder()
+                    .sender(SenderType.ASSISTANT)
+                    .painting(painting)
+                    .content(answer.text())
+                    .build();
+            messageRepository.save(a);
+
+             dto = MessageDTO.ChatAnswerDTO.builder()
+                    .paintingId(painting.getPaintingId())
+                    .answer(answer.text())
+                    .model(answer.model())
+                     .imgUrl(imageUrl)
+                    .build();
+
+            messagingTemplate.convertAndSend("/room/" + painting.getPaintingId(), dto);
+        }
+        return ApiResponse.of(SuccessStatus._OK, dto);
     }
 }

--- a/src/main/java/com/eyedia/eyedia/controller/DetectionEventController.java
+++ b/src/main/java/com/eyedia/eyedia/controller/DetectionEventController.java
@@ -80,6 +80,10 @@ public class DetectionEventController {
 
         List<Painting> paintings = paintingRepository.findByArtId(request.getArtId());
 
+        if (paintings == null || paintings.isEmpty()) {
+            throw new GeneralException(ErrorStatus.PAINTING_NOT_FOUND);
+        }
+
         var answer = docentChatService.answer(
                 docentChatService.gazeAreaPrompt(
                         paintings.get(0).getTitle(),

--- a/src/main/java/com/eyedia/eyedia/controller/DetectionEventController.java
+++ b/src/main/java/com/eyedia/eyedia/controller/DetectionEventController.java
@@ -21,6 +21,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @RestController
@@ -43,7 +44,8 @@ public class DetectionEventController {
         if (list.isEmpty()) {
             throw new GeneralException(ErrorStatus.PAINTING_NOT_FOUND);
         } else if (list.size() > 1) {
-            throw new GeneralException(ErrorStatus.PAINTING_CONFLICT);
+            List<Long> ids = list.stream().map(Painting::getPaintingId).toList();
+            throw new GeneralException(ErrorStatus.PAINTING_CONFLICT, Map.of("duplicatedPaintingIds", ids));
         } else {
             Painting painting = list.get(0);
             var exhibition = exhibitionRepository.findByPaintingsPaintingId(painting.getPaintingId())

--- a/src/main/java/com/eyedia/eyedia/controller/DocentController.java
+++ b/src/main/java/com/eyedia/eyedia/controller/DocentController.java
@@ -71,7 +71,7 @@ public class DocentController {
                 .audioUrl(audioUrl)
                 .build();
 
-        messagingTemplate.convertAndSendToUser(principal.getName(),"/room/user-" + principal.getName(), dto);
+        messagingTemplate.convertAndSendToUser(principal.getName(),"/room/" + req.getPaintingId(), dto);
         return dto;
     }
 }

--- a/src/main/java/com/eyedia/eyedia/dto/DetectAreaRequestDTO.java
+++ b/src/main/java/com/eyedia/eyedia/dto/DetectAreaRequestDTO.java
@@ -1,0 +1,57 @@
+package com.eyedia.eyedia.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import jakarta.validation.constraints.*;
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class DetectAreaRequestDTO {
+
+    @NotNull
+    private Long artId;
+
+    @NotEmpty
+    private List<@NotBlank String> q;
+
+    @NotNull
+    @Size(min = 1)
+    private List<CropItemDTO> list;
+
+    @Getter
+    @Setter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class CropItemDTO {
+
+        @NotBlank
+        private String cropId;
+
+        @NotBlank
+        private String cropPath;
+
+        @NotBlank
+        private String cropDescription;
+
+        @NotNull
+        private String primaryQuadrant; // 주요 사분면
+
+        @NotNull
+        private String quadrant; // 포함된 사분면
+
+        @DecimalMin(value = "0.0")
+        @DecimalMax(value = "1.0")
+        private Double ratio;
+    }
+}

--- a/src/main/java/com/eyedia/eyedia/dto/MessageDTO.java
+++ b/src/main/java/com/eyedia/eyedia/dto/MessageDTO.java
@@ -45,6 +45,7 @@ public class MessageDTO {
         private Long paintingId;
         private String answer; // LLM 도슨트 톤 답변
         private String model;  // (옵션) 모델명
+        private String imgUrl;
         private String audioUrl; // 선택: 프론트도 재생 가능
     }
 }

--- a/src/main/java/com/eyedia/eyedia/dto/PaintingMetadataRequest.java
+++ b/src/main/java/com/eyedia/eyedia/dto/PaintingMetadataRequest.java
@@ -13,6 +13,6 @@ public class PaintingMetadataRequest {
     private String title;
     private String artist;
     private String description;
-    private String exhibition;
+    private Long exhibition;
     private String imageUrl;
 }

--- a/src/main/java/com/eyedia/eyedia/global/error/exception/ExceptionAdvice.java
+++ b/src/main/java/com/eyedia/eyedia/global/error/exception/ExceptionAdvice.java
@@ -84,9 +84,15 @@ public class ExceptionAdvice {
     @ExceptionHandler(GeneralException.class)
     protected ResponseEntity<?> handleGeneralException(GeneralException e) {
         ErrorReasonDTO reason = e.getErrorReasonHttpStatus();
+        Object data = e.getData();
+
         return ResponseEntity
                 .status(reason.getHttpStatus())
-                .body(ApiResponse.onFailure(reason.getCode(), reason.getMessage(), null));
+                .body(ApiResponse.onFailure(
+                        reason.getCode(),
+                        reason.getMessage(),
+                        data
+                ));
     }
 
     /**

--- a/src/main/java/com/eyedia/eyedia/global/error/exception/GeneralException.java
+++ b/src/main/java/com/eyedia/eyedia/global/error/exception/GeneralException.java
@@ -2,20 +2,31 @@ package com.eyedia.eyedia.global.error.exception;
 
 import com.eyedia.eyedia.global.code.BaseErrorCode;
 import com.eyedia.eyedia.global.code.ErrorReasonDTO;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
 public class GeneralException extends RuntimeException {
 
-  private BaseErrorCode code;
+  private final BaseErrorCode code;
+  private final Object data;
+
+  public GeneralException(BaseErrorCode code) {
+    super(code.getReason().getMessage());
+    this.code = code;
+    this.data = null;
+  }
+
+  public GeneralException(BaseErrorCode code, Object data) {
+    super(code.getReason().getMessage());
+    this.code = code;
+    this.data = data;
+  }
 
   public ErrorReasonDTO getErrorReason() {
     return this.code.getReason();
   }
 
-  public ErrorReasonDTO getErrorReasonHttpStatus(){
+  public ErrorReasonDTO getErrorReasonHttpStatus() {
     return this.code.getReasonHttpStatus();
   }
 }

--- a/src/main/java/com/eyedia/eyedia/repository/PaintingRepository.java
+++ b/src/main/java/com/eyedia/eyedia/repository/PaintingRepository.java
@@ -15,4 +15,5 @@ public interface PaintingRepository extends JpaRepository<Painting, Long> {
     @Query("select p from Painting p where p.artId = :artId and p.user is null")
     List<Painting> findNullUserByArtId(@Param("artId") Long artId);
     Optional<Painting> findByPaintingId(Long paintingId);
+    List<Painting> findByArtId(Long artId);
 }

--- a/src/main/java/com/eyedia/eyedia/service/DocentChatService.java
+++ b/src/main/java/com/eyedia/eyedia/service/DocentChatService.java
@@ -53,9 +53,26 @@ public class DocentChatService {
         return new Prompt(system, user);
     }
 
-//    public Prompt gazeAreaPrompt(Painting p, String quadrant, String question){
-//        return new Prompt();
-//    }
+    public Prompt gazeAreaPrompt(String paintingTitle, String quadrant, String description){
+        String system = """
+                당신은 미술관의 도슨트입니다.\s
+                관람객에게 친절하고 감성적인 어조로 작품 속 객체를 설명해야 합니다.\s
+                너무 기술적이거나 딱딱하지 않게 풀어주세요.\s
+                그림에 없는 내용은 설명하지 말고, 해당 그림 외의 다른 그림은 언급하지 마세요.\s
+                작품 전체 설명보다는 각 객체에 대한 설명을 중심으로 해설해주세요.
+            """;
+
+        String user = """
+                아래는 %s 그림의 %s 분면에서 감지된 후보 객체 설명입니다: \s
+                %s\s
+                → 위의 내용을 바탕으로 관람객에게 설명을 작성해주세요.
+            """.formatted(
+                nz(paintingTitle), nz(quadrant),
+                nz(description)
+        );
+
+        return new Prompt(system, user);
+    }
 
     public Answer answer(Prompt prompt) {
         var system = prompt.system();

--- a/src/main/java/com/eyedia/eyedia/service/PaintingService.java
+++ b/src/main/java/com/eyedia/eyedia/service/PaintingService.java
@@ -67,10 +67,10 @@ public class PaintingService {
 //    }
 
     public Long saveMetadata(PaintingMetadataRequest request) {
-        Exhibition exhibition = exhibitionRepository.findByTitle(request.getExhibition())
+        Exhibition exhibition = exhibitionRepository.findById(request.getExhibition())
                 .orElseGet(() -> exhibitionRepository.save(
                         Exhibition.builder()
-                                .title(request.getExhibition())
+                                .exhibitionsId(request.getExhibition())
                                 .build()
                 ));
 

--- a/src/main/java/com/eyedia/eyedia/service/PaintingService.java
+++ b/src/main/java/com/eyedia/eyedia/service/PaintingService.java
@@ -91,6 +91,9 @@ public class PaintingService {
     public void deletePainting(Long paintingId) {
         Painting painting = paintingRepository.findByPaintingId(paintingId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.PAINTING_NOT_FOUND));
+        if(painting.getMessages() != null){
+            painting.getMessages().forEach(message -> messageRepository.delete(message));
+        }
         paintingRepository.delete(painting);
     }
 }


### PR DESCRIPTION
# 💡 PR Summary - <!--{ 작업 내용 }-->
<!-- 어떤 작업에 대한 PR 인지 위 주석에 적어주세요 -->

### 📝 Description

---
<!-- 어떤 작업을 했는지 간단하게 적어주세요 -->
작업 사항

### 🌲 Working Branch

---
<!-- 예시) feature/user -->
작업 브랜치

### 📖 Related Issues

---
<!-- 예시) #1 -->
이슈 번호

#108 

### 📚 Etc

---
<!-- 작업 중 특이사항이 생기면 적어주세요 -->
특이사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 작품 특정 영역을 질의하는 detect-area API 추가.
  - 채팅/해설이 사용자별이 아닌 작품별 방으로 전달되어 공동 열람이 용이.
  - 응답에 이미지 URL 포함으로 결과 확인성 향상.

- 개선
  - 중복 작품 감지 시 오류 응답에 중복 ID를 포함해 문제 파악 용이.
  - detect-area 엔드포인트 비로그인 접근 허용으로 사용 진입 장벽 축소.
  - 일반 오류 응답에 추가 데이터 포함하여 디버깅 정보 강화.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->