### PR TITLE
✨ Feat: 기존 채팅방 리스트 조회 기능 구현

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM openjdk:17-jdk-slim
+FROM openjdk:17.0.2-jdk-slim
 COPY build/libs/eyedia-0.0.1-SNAPSHOT.jar /app.jar
 ENTRYPOINT ["java", "-Dspring.profiles.active=dev", "-jar", "/app.jar"]

--- a/src/main/java/com/eyedia/eyedia/controller/DetectionEventController.java
+++ b/src/main/java/com/eyedia/eyedia/controller/DetectionEventController.java
@@ -40,7 +40,7 @@ public class DetectionEventController {
 
         MessageDTO.ChatImageResponseDTO message;
 
-        var list = paintingRepository.findNullUserByArtId(artId);
+        var list = paintingRepository.findByUserAndArtId(null, artId);
         if (list.isEmpty()) {
             throw new GeneralException(ErrorStatus.PAINTING_NOT_FOUND);
         } else if (list.size() > 1) {

--- a/src/main/java/com/eyedia/eyedia/repository/PaintingRepository.java
+++ b/src/main/java/com/eyedia/eyedia/repository/PaintingRepository.java
@@ -13,12 +13,13 @@ import java.util.Optional;
 
 @Repository
 public interface PaintingRepository extends JpaRepository<Painting, Long> {
-    @Query("""
-    select p from Painting p
-    where (:artId is null or p.artId = :artId)
-      and p.user is null
-""")
-    List<Painting> findNullUserByArtId(@Param("artId") Long artId);
+
+    @Query("SELECT p FROM Painting p WHERE p.artId = :artId AND p.user.usersId = :userId")
+    List<Painting> findByUserAndArtId(@Param("userId") Long userId, @Param("artId") Long artId);
+
+    @Query("SELECT p FROM Painting p WHERE p.user is null")
+    List<Painting> findNullUserByArtId();
+
     Optional<Painting> findByPaintingId(Long paintingId);
     List<Painting> findByArtId(Long artId);
     List<Painting> findByUserAndExhibition(User user, Exhibition exhibition);

--- a/src/main/java/com/eyedia/eyedia/service/PaintingService.java
+++ b/src/main/java/com/eyedia/eyedia/service/PaintingService.java
@@ -3,7 +3,6 @@ package com.eyedia.eyedia.service;
 
 import com.eyedia.eyedia.config.SecurityUtil;
 import com.eyedia.eyedia.domain.Exhibition;
-import com.eyedia.eyedia.domain.Message;
 import com.eyedia.eyedia.domain.Painting;
 import com.eyedia.eyedia.domain.User;
 import com.eyedia.eyedia.dto.MessageDTO;
@@ -16,12 +15,14 @@ import com.eyedia.eyedia.repository.MessageRepository;
 import com.eyedia.eyedia.repository.PaintingRepository;
 import com.eyedia.eyedia.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-import java.awt.*;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class PaintingService {
@@ -33,14 +34,28 @@ public class PaintingService {
 
     public UserFacingDTO.PaintingConfirmResponse confirmPainting(Long paintingId) {
         Long userId = SecurityUtil.getCurrentUserId();
+        Painting paintingRoom = paintingRepository.findByPaintingId(paintingId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.PAINTING_NOT_FOUND));
+
+        log.info("userId from SecurityUtil: {}", userId);
+        log.info("artId: {}", paintingRoom.getArtId());
+
+        List<Painting> paintingList = paintingRepository.findByUserAndArtId(userId, paintingRoom.getArtId());
+
+        for (Painting p : paintingList) {
+            log.info("painting id: {}, artId: {}, user: {}", p.getPaintingId(), p.getArtId(),
+                    p.getUser() != null ? p.getUser().getId() : "NULL");
+        }
+
+        if(!paintingList.isEmpty()) {
+            List<Long> ids = paintingList.stream().map(Painting::getPaintingId).toList();
+            throw new GeneralException(ErrorStatus.PAINTING_CONFLICT, Map.of("기존 감상한 이력", ids));
+        }
 
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
 
         // 사용자 연결
-        Painting paintingRoom = paintingRepository.findByPaintingId(paintingId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.PAINTING_NOT_FOUND));
-
         paintingRoom.setUser(user);
 
         Painting response = paintingRepository.save(paintingRoom);
@@ -92,7 +107,7 @@ public class PaintingService {
     }
 
     public List<Long> deletePainting() {
-        List<Painting> paintings = paintingRepository.findNullUserByArtId(null);
+        List<Painting> paintings = paintingRepository.findNullUserByArtId();
         List<Long> paintingIds = new ArrayList<>();
         paintings.forEach(painting -> {
             paintingIds.add(painting.getPaintingId());

--- a/src/main/java/com/eyedia/eyedia/service/PaintingService.java
+++ b/src/main/java/com/eyedia/eyedia/service/PaintingService.java
@@ -37,19 +37,11 @@ public class PaintingService {
         Painting paintingRoom = paintingRepository.findByPaintingId(paintingId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.PAINTING_NOT_FOUND));
 
-        log.info("userId from SecurityUtil: {}", userId);
-        log.info("artId: {}", paintingRoom.getArtId());
-
         List<Painting> paintingList = paintingRepository.findByUserAndArtId(userId, paintingRoom.getArtId());
-
-        for (Painting p : paintingList) {
-            log.info("painting id: {}, artId: {}, user: {}", p.getPaintingId(), p.getArtId(),
-                    p.getUser() != null ? p.getUser().getId() : "NULL");
-        }
 
         if(!paintingList.isEmpty()) {
             List<Long> ids = paintingList.stream().map(Painting::getPaintingId).toList();
-            throw new GeneralException(ErrorStatus.PAINTING_CONFLICT, Map.of("기존 감상한 이력", ids));
+            throw new GeneralException(ErrorStatus.PAINTING_CONFLICT, Map.of("newChatroom", paintingId, "history", ids ));
         }
 
         User user = userRepository.findById(userId)
@@ -74,6 +66,22 @@ public class PaintingService {
 
 
     public List<MessageDTO.ChatMessageDTO> getChatMessagesByPaintingId(Long paintingId) {
+        Painting painting = paintingRepository.findByPaintingId(paintingId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.PAINTING_NOT_FOUND));
+
+        if(painting.getUser() == null){
+            Long userId = SecurityUtil.getCurrentUserId();
+
+            User user = userRepository.findById(userId)
+                    .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+            painting.setUser(user);
+
+            Painting response = paintingRepository.save(painting);
+
+            exhibitionCommandService.addVisit(response);
+        }
+
         return messageRepository.findByPainting_PaintingIdOrderByCreatedAtAsc(paintingId).stream()
                 .map(message -> MessageDTO.ChatMessageDTO.builder()
                         .sender(message.getSender())
@@ -84,7 +92,7 @@ public class PaintingService {
                 .toList();
     }
 
-    public Long saveMetadata(PaintingMetadataRequest request) {
+    public void saveMetadata(PaintingMetadataRequest request) {
         Exhibition exhibition = exhibitionRepository.findById(request.getExhibition())
                 .orElseGet(() -> exhibitionRepository.save(
                         Exhibition.builder()
@@ -102,8 +110,6 @@ public class PaintingService {
                 .build();
 
         paintingRepository.save(painting);
-
-        return painting.getPaintingId();
     }
 
     public List<Long> deletePainting() {


### PR DESCRIPTION
# 💡 PR Summary - 기존 채팅방 리스트 조회 기능 구현
<!-- 어떤 작업에 대한 PR 인지 위 주석에 적어주세요 -->

### 📝 Description

---
<!-- 어떤 작업을 했는지 간단하게 적어주세요 -->
userId와 artId로 해당 사용자가 기존에 감상한 이력이 있는 작품인지 검색
- 있으면 → 409 에러 (기존 이력 및 새로 개설된 채팅방 id 전달)
     - 기존 이력으로 선택 → /{기존 채팅방 id}/chats → 새로 개설된 채팅방은 user가 null이므로 추후 아이웨어 연동 페이지에서 /delete로 삭제됨
    - 새 채팅으로 선택 → /{새 채팅방 id}/chats → 해당 채팅방Id로 채팅방의 user 조회 → 값이 null이면 user 업데이트
- 없으면 → 새 채팅방 개설

### 🌲 Working Branch

---
<!-- 예시) feature/user -->
작업 브랜치

### 📖 Related Issues

---
<!-- 예시) #1 -->
이슈 번호

#122 

### 📚 Etc

---
<!-- 작업 중 특이사항이 생기면 적어주세요 -->
특이사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 사용자가 동일 미술품을 이미 소유한 경우 충돌 감지 및 오류 처리 개선
  * 그림 채팅 접근 시 사용자 연결 및 방문 기록 처리 개선

* **Chores**
  * 외부 인증(Naver, Google)용 환경변수 추가 및 컨테이너 환경 전달 설정
  * 내부 쿼리 로직 정리 및 컨테이너 이미지 기반 업데이트 (런타임 이미지 버전 조정)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->