### PR TITLE
🐛 Fix: /detect에서 nullUser인 paintingId 추출 로직 수정

### DIFF
--- a/src/main/java/com/eyedia/eyedia/controller/DetectionEventController.java
+++ b/src/main/java/com/eyedia/eyedia/controller/DetectionEventController.java
@@ -40,7 +40,7 @@ public class DetectionEventController {
 
         MessageDTO.ChatImageResponseDTO message;
 
-        var list = paintingRepository.findByUserAndArtId(null, artId);
+        var list = paintingRepository.findNullUserByArtId(artId);
         if (list.isEmpty()) {
             throw new GeneralException(ErrorStatus.PAINTING_NOT_FOUND);
         } else if (list.size() > 1) {

--- a/src/main/java/com/eyedia/eyedia/repository/PaintingRepository.java
+++ b/src/main/java/com/eyedia/eyedia/repository/PaintingRepository.java
@@ -17,8 +17,8 @@ public interface PaintingRepository extends JpaRepository<Painting, Long> {
     @Query("SELECT p FROM Painting p WHERE p.artId = :artId AND p.user.usersId = :userId")
     List<Painting> findByUserAndArtId(@Param("userId") Long userId, @Param("artId") Long artId);
 
-    @Query("SELECT p FROM Painting p WHERE p.user is null")
-    List<Painting> findNullUserByArtId();
+    @Query("SELECT p FROM Painting p WHERE p.user is null AND (p.artId = :artId OR :artId is null)")
+    List<Painting> findNullUserByArtId(@Param("artId") Long artId);
 
     Optional<Painting> findByPaintingId(Long paintingId);
     List<Painting> findByArtId(Long artId);

--- a/src/main/java/com/eyedia/eyedia/service/PaintingService.java
+++ b/src/main/java/com/eyedia/eyedia/service/PaintingService.java
@@ -113,7 +113,7 @@ public class PaintingService {
     }
 
     public List<Long> deletePainting() {
-        List<Painting> paintings = paintingRepository.findNullUserByArtId();
+        List<Painting> paintings = paintingRepository.findNullUserByArtId(null);
         List<Long> paintingIds = new ArrayList<>();
         paintings.forEach(painting -> {
             paintingIds.add(painting.getPaintingId());


### PR DESCRIPTION
# 💡 PR Summary - <!--{ 작업 내용 }-->
<!-- 어떤 작업에 대한 PR 인지 위 주석에 적어주세요 -->

### 📝 Description

---
<!-- 어떤 작업을 했는지 간단하게 적어주세요 -->
작업 사항

### 🌲 Working Branch

---
<!-- 예시) feature/user -->
작업 브랜치

### 📖 Related Issues

---
<!-- 예시) #1 -->
이슈 번호


### 📚 Etc

---
<!-- 작업 중 특이사항이 생기면 적어주세요 -->
특이사항

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 아트 작품 검색 및 삭제 기능의 데이터베이스 조회 로직을 개선하였습니다. 특정 아트 ID를 기준으로 하는 그림 데이터 검색 처리를 최적화하여 쿼리 정확성과 실행 효율성을 높였습니다. 이를 통해 더욱 안정적인 데이터 조회 성능을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->